### PR TITLE
#16 bug inconsistent mute state

### DIFF
--- a/space_dodge/drawing/pause_menu/pause_function.py
+++ b/space_dodge/drawing/pause_menu/pause_function.py
@@ -36,7 +36,7 @@ def pause_menu(score, elapsedTime, highscore, highscoreBreak, mute):
 
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
-                return False
+                return False, mute
             elif event.type in [pygame.KEYDOWN, pygame.MOUSEBUTTONDOWN]:
                 keys = pygame.key.get_pressed()
                 if keys[pygame.K_m] or unmutePauseButton.clicked() or mutePauseButton.clicked():
@@ -44,10 +44,11 @@ def pause_menu(score, elapsedTime, highscore, highscoreBreak, mute):
                 elif keys[pygame.K_ESCAPE] or xButton.clicked():
                     pygame.mixer.music.stop()
                     pygame.mixer.music.unload()
-                    pygame.mixer.music.load(ref("assets/sounds/background_music/background_music.mp3"))
-                    pygame.mixer.music.play(-1)
-                    return True
+                    if not mute:
+                        pygame.mixer.music.load(ref("assets/sounds/background_music/background_music.mp3"))
+                        pygame.mixer.music.play(-1)
+                    return True, mute
                 elif settingsButton.clicked():
-                    pause = settings_menu(mute)
+                    pause, mute = settings_menu(mute)
 
         pygame.display.update()

--- a/space_dodge/drawing/pause_menu/settings.py
+++ b/space_dodge/drawing/pause_menu/settings.py
@@ -16,7 +16,6 @@ xButton = Button(x_button_icon, 665, 175)  # Create the x button object
 
 
 
-@pause_time
 def settings_menu(mute):
     slider = Slider(WINDOW, 350, 400, 100, 30, min=0, max=100, initial=pygame.mixer.music.get_volume() * 100)
     output = TextBox(WINDOW, 500, 395, 75, 50, fontSize=30)
@@ -28,6 +27,9 @@ def settings_menu(mute):
         WINDOW.blit(pause_background, (0, 0))
         WINDOW.blit(PAUSE_FONT.render("SETTINGS MENU", 1, "white"), (250, 176))
         WINDOW.blit(mutePauseButton.image if mute else unmutePauseButton.image, (180, 430))
+        if pygame.mixer.music.get_busy() is False and mute is False:
+            pygame.mixer.music.load("assets/sounds/background_music/pause_screen/pause_music.mp3")
+            pygame.mixer.music.play(-1)
         pygame.mixer.music.pause() if mute else pygame.mixer.music.unpause()
         WINDOW.blit(slider_title, (200, 390))
         xButton.draw()
@@ -36,13 +38,14 @@ def settings_menu(mute):
         events = pygame.event.get()
         for event in events:
             if event.type == pygame.QUIT:
-                return mute
+                pause = False
+                return pause, mute
             elif event.type in [pygame.KEYDOWN, pygame.MOUSEBUTTONDOWN]:
                 keys = pygame.key.get_pressed()
                 if keys[pygame.K_m] or unmutePauseButton.clicked() or mutePauseButton.clicked():
                     mute = not mute
                 elif keys[pygame.K_ESCAPE] or xButton.clicked():
-                    return mute
+                    return pause, mute
 
         slider.listen(events)
         output.setText(slider.getValue())

--- a/space_dodge/drawing/pause_menu/settings.py
+++ b/space_dodge/drawing/pause_menu/settings.py
@@ -36,13 +36,13 @@ def settings_menu(mute):
         events = pygame.event.get()
         for event in events:
             if event.type == pygame.QUIT:
-                return False
+                return mute
             elif event.type in [pygame.KEYDOWN, pygame.MOUSEBUTTONDOWN]:
                 keys = pygame.key.get_pressed()
                 if keys[pygame.K_m] or unmutePauseButton.clicked() or mutePauseButton.clicked():
                     mute = not mute
                 elif keys[pygame.K_ESCAPE] or xButton.clicked():
-                    return True
+                    return mute
 
         slider.listen(events)
         output.setText(slider.getValue())

--- a/space_dodge/drawing/title_screen/draw_title_screen.py
+++ b/space_dodge/drawing/title_screen/draw_title_screen.py
@@ -15,12 +15,11 @@ pygame.mixer.init()
 
 
 # Draw the title screen
-def draw_title():
+def draw_title(mute):
     # Load the title screen music
     pygame.mixer.music.load(ref("assets/sounds/background_music/title_screen/title_screen_music.mp3"))
     pygame.mixer.music.set_volume(0.5)
     pygame.mixer.music.play(loops=-1)
-    mute = False
     start = False
 
     # Define Button objects

--- a/space_dodge/drawing/title_screen/draw_title_screen.py
+++ b/space_dodge/drawing/title_screen/draw_title_screen.py
@@ -41,7 +41,7 @@ def draw_title():
 
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
-                return False, 0.0
+                return False, 0.0, mute
             elif event.type == pygame.MOUSEBUTTONDOWN:
                 if startButton.clicked():
                     start = True
@@ -54,11 +54,11 @@ def draw_title():
 
         pygame.display.update()
 
-    while True:
+    while start:
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
-                return False, 0.0
+                return False, 0.0, mute
             elif event.type == pygame.KEYDOWN:
                 running, startTime = keybindings_screen(None)
-                return running, startTime
+                return running, startTime, mute
         welcome_screen()

--- a/space_dodge/main.py
+++ b/space_dodge/main.py
@@ -61,7 +61,7 @@ def main():
 
         if lives == 4:
             # Draw the title screen
-            running, startTime = draw_title()
+            running, startTime, mute = draw_title()
             lives = 3
             # Play the background music
             pygame.mixer.music.load(ref("assets/sounds/background_music/background_music.mp3"))
@@ -117,7 +117,7 @@ def main():
                     pausedTimes.append(pausedTime)
                 if (pauseButton.clicked() or
                         keys[pygame.K_p]):
-                    running, pausedTime = pause_menu(score, elapsedTime, highscore, highscoreBreak, mute)
+                    running, pausedTime, mute = pause_menu(score, elapsedTime, highscore, highscoreBreak, mute)
                     pausedTimes.append(pausedTime)
 
         if highscore == 0 and not highscoreFileFound:

--- a/space_dodge/main.py
+++ b/space_dodge/main.py
@@ -61,7 +61,7 @@ def main():
 
         if lives == 4:
             # Draw the title screen
-            running, startTime, mute = draw_title()
+            running, startTime, mute = draw_title(mute)
             lives = 3
             # Play the background music
             pygame.mixer.music.load(ref("assets/sounds/background_music/background_music.mp3"))
@@ -117,7 +117,7 @@ def main():
                     pausedTimes.append(pausedTime)
                 if (pauseButton.clicked() or
                         keys[pygame.K_p]):
-                    running, pausedTime, mute = pause_menu(score, elapsedTime, highscore, highscoreBreak, mute)
+                    running, mute, pausedTime = pause_menu(score, elapsedTime, highscore, highscoreBreak, mute)
                     pausedTimes.append(pausedTime)
 
         if highscore == 0 and not highscoreFileFound:
@@ -134,7 +134,8 @@ def main():
                     WIDTH / 2 - highscoreBrokenText.get_width() / 2,
                     HEIGHT / 2 - highscoreBrokenText.get_height() / 2))
                 pygame.display.update()
-                pygame.mixer.Sound.play(highscoreSound)
+                if not mute:
+                    pygame.mixer.Sound.play(highscoreSound)
                 highscoreSoundPlayed = True
                 startTime1 = time.time()
                 while not time.time() > startTime1 + 1:  # A while loop which waits for 1 second
@@ -200,8 +201,9 @@ def main():
                         WINDOW.blit(timeText, (WIDTH / 2 - timeText.get_width() / 2,
                                                HEIGHT / 2 + loseText.get_height() + timeText.get_height() + 100 / 2))
                         pygame.display.update()
-                        pygame.mixer.Sound.play(GameOverSound)
-                        pygame.mixer.Sound.play(sadSound)
+                        if not mute:
+                            pygame.mixer.Sound.play(GameOverSound)
+                            pygame.mixer.Sound.play(sadSound)
                         startTime1 = time.time()
                         while not time.time() > startTime1 + 5:  # A while loop which waits for 5 seconds
                             for event in pygame.event.get():   # but the game can still be quit during this time
@@ -212,7 +214,9 @@ def main():
                                 break
                         lives = 4
                         break
-
+            if pygame.mixer.music.get_busy() is False and mute is False:
+                pygame.mixer.music.load(ref("assets/sounds/background_music/background_music.mp3"))
+                pygame.mixer.music.play(-1)
             pygame.mixer.music.pause() if mute else pygame.mixer.music.unpause()  # Pause or unpause the music
 
         if not running:


### PR DESCRIPTION
This pull request includes changes to handle the mute functionality more consistently across different parts of the game. The changes ensure that the mute state is properly passed and respected in various menus and the main game loop.

Key changes include:

### Pause Menu Enhancements:
* Modified the `pause_menu` function to return the mute state along with the pause state and to conditionally load and play background music based on the mute state (`space_dodge/drawing/pause_menu/pause_function.py`).

### Settings Menu Adjustments:
* Updated the `settings_menu` function to return the mute state and to ensure the background music is managed based on the mute state (`space_dodge/drawing/pause_menu/settings.py`). [[1]](diffhunk://#diff-87c69cdb54adf6d427922ef7a767c8985feee163c8a684154af27e030e12031eL19) [[2]](diffhunk://#diff-87c69cdb54adf6d427922ef7a767c8985feee163c8a684154af27e030e12031eR30-R32) [[3]](diffhunk://#diff-87c69cdb54adf6d427922ef7a767c8985feee163c8a684154af27e030e12031eL39-R48)

### Title Screen Updates:
* Adjusted the `draw_title` function to accept and return the mute state, ensuring the title screen music is handled appropriately (`space_dodge/drawing/title_screen/draw_title_screen.py`). [[1]](diffhunk://#diff-a827726a4792a7757e03259d985f6ea3d5185ebbd87bfc9484c89375eb2e0b1cL18-L23) [[2]](diffhunk://#diff-a827726a4792a7757e03259d985f6ea3d5185ebbd87bfc9484c89375eb2e0b1cL44-R43) [[3]](diffhunk://#diff-a827726a4792a7757e03259d985f6ea3d5185ebbd87bfc9484c89375eb2e0b1cL57-R62)

### Main Game Loop Modifications:
* Modified the `main` function to pass the mute state to the title screen and pause menu functions, and to conditionally play sound effects and background music based on the mute state (`space_dodge/main.py`). [[1]](diffhunk://#diff-52862f8857e2644eb6a2fdb308cf0346e48f13c84c3e7bdfcf11815ef148210aL64-R64) [[2]](diffhunk://#diff-52862f8857e2644eb6a2fdb308cf0346e48f13c84c3e7bdfcf11815ef148210aL120-R120) [[3]](diffhunk://#diff-52862f8857e2644eb6a2fdb308cf0346e48f13c84c3e7bdfcf11815ef148210aR137) [[4]](diffhunk://#diff-52862f8857e2644eb6a2fdb308cf0346e48f13c84c3e7bdfcf11815ef148210aR204) [[5]](diffhunk://#diff-52862f8857e2644eb6a2fdb308cf0346e48f13c84c3e7bdfcf11815ef148210aL215-R219)