### PR TITLE
Add small delay to drawing title screen, as to not consume 100% CPU

### DIFF
--- a/space_dodge/drawing/title_screen/draw_title_screen.py
+++ b/space_dodge/drawing/title_screen/draw_title_screen.py
@@ -1,5 +1,5 @@
 import pygame
-
+import time
 from classes.button import Button
 from drawing.tutorial_and_information.keybindings import keybindings_screen
 from drawing.pause_menu.settings import settings_menu
@@ -31,6 +31,7 @@ def draw_title():
                             HEIGHT - settings_icon_frames[1].get_height())
 
     while not start:
+        time.sleep(3 / 1000)
         WINDOW.blit(title_screen_background, (0, 0))
         startButton.draw()
         if mute:


### PR DESCRIPTION
**Add a small delay to `draw_title()`**, as it would otherwise **consume 100% of the CPU when on the title screen.**