### PR TITLE
Potential fix for code scanning alert no. 2: Client-side URL redirect

### DIFF
--- a/website/stats_down.html
+++ b/website/stats_down.html
@@ -44,7 +44,11 @@
 
 		// Redirect logic
 		const params = new URLSearchParams(window.location.search);
-		const from = params.get("from") || "contributors";
+		const allowedPages = ["contributors", "stats", "dashboard"]; // Whitelist of allowed pages
+		let from = params.get("from");
+		if (!allowedPages.includes(from)) {
+			from = "contributors"; // Default page
+		}
 
 	    // Auto-retry at UTC hour
 	    if (minutes === "00" && seconds === "00") {

--- a/website/stats_down.html
+++ b/website/stats_down.html
@@ -44,10 +44,10 @@
 
 		// Redirect logic
 		const params = new URLSearchParams(window.location.search);
-		const allowedPages = ["contributors", "stats", "dashboard"]; // Whitelist of allowed pages
+		const allowedPages = ["contributors", "stats"]; // Whitelist of allowed pages
 		let from = params.get("from");
 		if (!allowedPages.includes(from)) {
-			from = "contributors"; // Default page
+			from = "stats"; // Default page
 		}
 
 	    // Auto-retry at UTC hour


### PR DESCRIPTION
Potential fix for [https://github.com/Spacexplorer11/Space_Dodge/security/code-scanning/2](https://github.com/Spacexplorer11/Space_Dodge/security/code-scanning/2)

To fix the issue, we will validate the `from` parameter against a predefined whitelist of allowed values. This ensures that only trusted and expected values can be used for redirection. If the `from` parameter is not in the whitelist, we will redirect to a default page (e.g., `contributors.html`). This approach prevents attackers from exploiting the redirection logic.

**Steps to implement the fix:**
1. Define a whitelist of allowed values for the `from` parameter.
2. Check if the extracted `from` value is in the whitelist.
3. If the value is not in the whitelist, use a default value for redirection.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
