### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build_site:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/Spacexplorer11/Space_Dodge/security/code-scanning/4](https://github.com/Spacexplorer11/Space_Dodge/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the `build_site` job, explicitly setting the permissions to the minimum required. Since the job only needs to read the repository contents and upload artifacts, we will set `contents: read`. This ensures that the job does not have unnecessary `write` permissions.

The `deploy` job already has an explicit `permissions` block, so no changes are needed there.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
